### PR TITLE
Fix maintainer Url

### DIFF
--- a/package.html
+++ b/package.html
@@ -58,7 +58,7 @@
              },
 
              maintainerUrl(maintainer) {
-                 return `https://github.com/${maintainer}/${maintainer}`;
+                 return `https://github.com/${maintainer}`;
              },
 
              async loadData() {


### PR DESCRIPTION
Fix maintainer Url in package.html page. Correct Url for GitHub profile is `https://github.com/${maintainer}`.