### PR TITLE
Repology: do not add all metadata to JSON

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -110,7 +110,8 @@ def main():
             seen_versions.add(str(version))
             meta = {"name": str(version)}
             for key, h in hashes.items():
-                meta[key] = h
+                if isinstance(key, str) and isinstance(h, str):
+                    meta[key] = h
             versions.append(meta)
 
         # Repology wants a completely different format for versions
@@ -265,7 +266,10 @@ def main():
                 {"name": dep, "description": descriptions.get(dep, "")}
             )
         outfile = os.path.join(here, "data", "packages", "%s.json" % pkg)
-        write_json(meta, outfile)
+        try:
+            write_json(meta, outfile)
+        except Exception as e:
+            print(f"cannot update {pkg}: {str(e)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Not all metadata is serializable in JSON (e.g. Python functions are not), therefore filter the information we are going to submit to repology. Currently this is failing because of `dakota`, which uses a function to compute git submodules.

Modifications:
- [x] Filter version metadata to ensure information is serializable
- [x] Don't fail generating the whole update if a package cannot be dumped.