### PR TITLE
generate_packages/repology: no url for isdevelop; add licenses and tags

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -219,11 +219,11 @@ def main():
             "version": repology_versions,
             "summary": meta["description"],
             "maintainers": meta["maintainers"],
-            "licenses": pkg.licenses,
+            "licenses": list(pkg.licenses.values()),
             "downloads": urls,
             "homepages": [pkg.homepage],
             "patches": patches_repology,
-            "categories": pkg.tags,
+            "categories": getattr(pkg, "tags", []),
             "dependencies": meta["dependencies"],
             "alias": meta["aliases"],
         }

--- a/generate_packages.py
+++ b/generate_packages.py
@@ -117,15 +117,18 @@ def main():
         # Repology wants a completely different format for versions
         repology_versions = []
         for version, version_meta in pkg.versions.items():
+            meta = {"version": str(version)}
+
             try:
                 url = pkg.url_for_version(version)
             except BaseException as e:
                 url = pkg.all_urls
-            meta = {"version": str(version), "downloads": [url]}
 
             # Is there a develop branch?
             if version.isdevelop():
                 meta["branch"] = str(version)
+            else:
+                meta["downloads"] = [url]
 
             # We can only get specific deps with concretization, which doesn't always work
             # try:
@@ -216,11 +219,11 @@ def main():
             "version": repology_versions,
             "summary": meta["description"],
             "maintainers": meta["maintainers"],
-            "licenses": {},
+            "licenses": pkg.licenses,
             "downloads": urls,
             "homepages": [pkg.homepage],
             "patches": patches_repology,
-            "categories": [],
+            "categories": pkg.tags,
             "dependencies": meta["dependencies"],
             "alias": meta["aliases"],
         }


### PR DESCRIPTION
A lot of spack packages on repology (https://repology.org/repository/spack/problems) are marked with errors like:
> Download link https://github.com/LLNL/metall/archive/refs/tags/vdevelop.tar.gz is [dead](https://repology.org/link/https://github.com/LLNL/metall/archive/refs/tags/vdevelop.tar.gz) (HTTP 404) for more than a month and should be replaced by alive link (see other packages for hints).

This is caused by us writing a `downloads` entry for develop/main/master branch versions:
```console
$ curl -L https://raw.githubusercontent.com/spack/packages.spack.io/main/data/repology.json | jq '.packages["metall"].version'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17.5M  100 17.5M    0     0  10.2M      0  0:00:01  0:00:01 --:--:-- 10.2M
[
  {
    "version": "master",
    "downloads": [
      "https://github.com/LLNL/metall/archive/refs/tags/vmaster.tar.gz"
    ],
    "branch": "master"
  },
  {
    "version": "develop",
    "downloads": [
      "https://github.com/LLNL/metall/archive/refs/tags/vdevelop.tar.gz"
    ],
    "branch": "develop"
  },
  {
    "version": "0.28",
    "downloads": [
      "https://github.com/LLNL/metall/archive/refs/tags/v0.28.tar.gz"
    ]
  },
```

This PR only writes the `downloads` entries if `not version.isdevelop()`.

This PR also adds the license and tag information (with licenses as a list, not a dict; I couldn't find the upstream requirements). This will probably need to get support added in https://github.com/repology/repology-updater/blob/master/repology/parsers/parsers/spack.py.

After sorting the output of this branch and the latest version online with `jq -S '.' data/repology.json.orig > data/repology.json.orig.sorted`, I'm getting the following diff (removed unrelated changes due packages merged since online repology.json was created):
```diff
$ diff -w data/repology.json.orig.sorted data/repology.json.sorted  | head -n 200
2,3c2,3
<   "last_update": "2024-08-13 05:13:40.209745",
<   "num_packages": 8088,
---
>   "last_update": "2024-08-13 13:17:37.623884",
>   "num_packages": 8234,
28c28
<       "licenses": {},
---
>       "licenses": [],
38,40d37
<           "downloads": [
<             []
<           ],
69c66
<       "licenses": {},
---
>       "licenses": [],
97c94,97
<       "categories": [],
---
>       "categories": [
>         "windows",
>         "detectable"
>       ],
105c105,107
<       "licenses": {},
---
>       "licenses": [
>         "LGPL-2.0-only"
>       ],
212c206,209
<       "categories": [],
---
>       "categories": [
>         "compiler",
>         "detectable"
>       ],
250c247,249
<       "licenses": {},
---
>       "licenses": [
>         "GPL-2.0-or-later AND LGPL-2.1-or-later"
>       ],
287,289d285
<           "downloads": [
<             "https://ftpmirror.gnu.org/gcc/gcc-master/gcc-master.tar.xz"
<           ],
628c624,626
<       "licenses": {},
---
>       "licenses": [
>         "LGPL-3.0-or-later"
>       ],
638,640d635
<           "downloads": [
<             "https://github.com/abacusmodeling/abacus-develop/archive/refs/tags/vdevelop.tar.gz"
<           ],
683c678,680
<       "licenses": {},
---
>       "licenses": [
>         "ISC"
>       ],
```
This indicates that the downloads of `vdevelop.tar.gz` links are now gone, and licenses and categories have been added.

