### PR TITLE
generate_packages/repology: specify git url in isdevelop pkgs, and in class-wide urls

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -127,7 +127,8 @@ def main():
             # Is there a develop branch?
             if version.isdevelop():
                 meta["branch"] = str(version)
-                meta["downloads"] = getattr(pkg, "git", "")
+                if hasattr(pkg, "git"):
+                    meta["downloads"] = pkg.git
             else:
                 meta["downloads"] = [url]
 

--- a/generate_packages.py
+++ b/generate_packages.py
@@ -128,7 +128,7 @@ def main():
             if version.isdevelop():
                 meta["branch"] = str(version)
                 if hasattr(pkg, "git"):
-                    meta["downloads"] = pkg.git
+                    meta["downloads"] = [pkg.git]
             else:
                 meta["downloads"] = [url]
 

--- a/generate_packages.py
+++ b/generate_packages.py
@@ -127,6 +127,7 @@ def main():
             # Is there a develop branch?
             if version.isdevelop():
                 meta["branch"] = str(version)
+                meta["downloads"] = getattr(pkg, "git", "")
             else:
                 meta["downloads"] = [url]
 
@@ -212,6 +213,10 @@ def main():
             urls = [pkg.url_for_version(x["name"]) for x in versions]
         except:
             urls = pkg.all_urls
+
+        # Add git repository to urls if specified
+        if hasattr(pkg, "git"):
+            urls.append(pkg.git)
 
         # Add to repology
         repology_pkg = {


### PR DESCRIPTION
Repology apparently requires at least one download link per package, either associated with a version or with the package. This ensures that when only a git branch is used for all versions, the the git repo link is provided, both on the version entry and the overall list of the package.

Example package `tramonto`, now has `downloads` and `version: downloads`:
```json
    "tramonto": {
      "alias": [],
      "categories": [],
      "dependencies": [
        "cmake",
        "gmake",
        "ninja",
        "trilinos"
      ],
      "downloads": [
        "https://github.com/Tramonto/Tramonto.git"
      ],
      "homepages": [
        "https://software.sandia.gov/tramonto/"
      ],
      "licenses": [],
      "maintainers": [],
      "name": "tramonto",
      "patches": [],
      "summary": "Tramonto: Software for Nanostructured Fluids in Materials and Biology\n",
      "version": [
        {
          "branch": "develop",
          "downloads": [
            "https://github.com/Tramonto/Tramonto.git"
          ],
          "version": "develop"
        }
      ]
    },
```