### PR TITLE
generate_packages/repology: add repository:{url,type,branch} for git versions

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -128,7 +128,7 @@ def main():
             if version.isdevelop():
                 meta["branch"] = str(version)
                 if hasattr(pkg, "git"):
-                    meta["downloads"] = [pkg.git]
+                    meta["repositories"] = {"url": pkg.git, "type": "git", "branch": str(version)}
             else:
                 meta["downloads"] = [url]
 


### PR DESCRIPTION
In response to https://github.com/repology/repology-updater/pull/1422#issuecomment-2289539631.

Not removing `branch` at `version` level yet since that will require updates on the repology parser side first.