### PR TITLE
generate_packages.py: sort versions new to old

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -102,7 +102,7 @@ def main():
 
         versions = []
         seen_versions = set()
-        for version, hashes in pkg.versions.items():
+        for version, hashes in sorted(pkg.versions.items(), reverse=True):
 
             # Skip a version we have already seen
             if str(version) in seen_versions:
@@ -113,7 +113,6 @@ def main():
                 if isinstance(key, str) and isinstance(h, str):
                     meta[key] = h
             versions.append(meta)
-        versions.sort(key=lambda x: x["name"])
 
         # Repology wants a completely different format for versions
         repology_versions = []


### PR DESCRIPTION
This PR sort packages new to old. This changes to produce the following for [py-ipython](https://packages.spack.io/package.html?name=py-ipython) (old -> new):
![image](https://github.com/user-attachments/assets/6e420a19-7e6a-4baa-9f32-d5b287a5a16a) ![image](https://github.com/user-attachments/assets/af0608d9-cbea-485f-888f-d65b0e7365eb)


