### PR TITLE
feat: separate deprecated versions from main list

### DIFF
--- a/package.html
+++ b/package.html
@@ -32,6 +32,7 @@
              patches: [],
              conflicts: [],
              versions: [],
+             versions_deprecated: [],
 
              initialized: false,
              notFound: false,
@@ -87,6 +88,7 @@
                 this.patches = data.patches;
                 this.conflicts = data.conflicts;
                 this.versions = data.versions;
+                this.versions_deprecated = data.versions_deprecated;
             }
          };
 
@@ -306,6 +308,25 @@
                                             <div x-show="(index + 1) % columns === 0" class="w-full"></div>
                                           </template>
                                         </ul>
+                                      </div>
+                                </div>
+                            </div>
+
+                            <div class="card-body border-b border-base-200 p-6">
+                                <div>
+                                    <h2 class="card-title text-base">Deprecated versions</h2>
+                                    <div>
+                                        <ul class="flex flex-wrap">
+                                          <template x-for="(version, index) in versions_deprecated">
+                                            <li class="w-1/2">
+                                              <span x-text="version.name" x-bind:title="version.sha256"></span>
+                                            </li>
+                                            <div x-show="(index + 1) % columns === 0" class="w-full"></div>
+                                          </template>
+                                        </ul>
+                                        <div class="text-gray-400 font-light" x-show="versions_deprecated.length == 0">
+                                            There are no deprecated versions
+                                        </div>
                                       </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Currently, https://packages.spack.io shows deprecated versions alongside regular versions (e.g. https://packages.spack.io/package.html?name=ants). This is confusing, in particular for cases (like `ants`) where the deprecated version appears newer than the other versions.

Furthermore, on Repology the same happens and causes packages to be marked as problematic or outdated, e.g. https://repology.org/project/ants-advanced-normalization-tools/versions.

This PR separates out deprecated versions on https://packages.spack.io and doesn't include them at all in `repology.json`.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/828c7e74-41c4-4e23-86db-323d758c18d2) | ![image](https://github.com/user-attachments/assets/0e95f19d-db0e-4b24-8b92-903048947ca1)

Diff segment for `repology.json`:
```diff
@@ -6845,7 +6854,6 @@
                 "zlib-api"
             ],
             "downloads": [
-                "https://github.com/ANTsX/ANTs/archive/v20220205.tar.gz",
                 "https://github.com/ANTsX/ANTs/archive/v2.5.1.tar.gz",
                 "https://github.com/ANTsX/ANTs/archive/v2.4.3.tar.gz",
                 "https://github.com/ANTsX/ANTs/archive/v2.4.0.tar.gz",
@@ -6891,12 +6899,6 @@
                         "https://github.com/ANTsX/ANTs/archive/v2.5.1.tar.gz"
                     ],
                     "version": "2.5.1"
-                },
-                {
-                    "downloads": [
-                        "https://github.com/ANTsX/ANTs/archive/v20220205.tar.gz"
-                    ],
-                    "version": "20220205"
                 }
             ]
         },
```