### PR TITLE
feat: add commit/tag/branch versions as repository to repology

### DIFF
--- a/generate_packages.py
+++ b/generate_packages.py
@@ -146,6 +146,8 @@ def main():
                 meta["repositories"] = [{"url": pkg.git, "type": "git", "commit": version_meta["commit"]}]
             elif "tag" in version_meta and hasattr(pkg, "git"):
                 meta["repositories"] = [{"url": pkg.git, "type": "git", "tag": version_meta["tag"]}]
+            elif "branch" in version_meta and hasattr(pkg, "git"):
+                meta["repositories"] = [{"url": pkg.git, "type": "git", "branch": version_meta["branch"]}]
             else:
                 meta["downloads"] = [url]
 

--- a/generate_packages.py
+++ b/generate_packages.py
@@ -142,6 +142,13 @@ def main():
                 meta["branch"] = str(version)
                 if hasattr(pkg, "git"):
                     meta["repositories"] = [{"url": pkg.git, "type": "git", "branch": str(version)}]
+            elif "commit" in version_meta and hasattr(pkg, "git"):
+                meta["repositories"] = [{"url": pkg.git, "type": "git", "commit": version_meta["commit"]}]
+            elif "tag" in version_meta and hasattr(pkg, "git"):
+                meta["repositories"] = [{"url": pkg.git, "type": "git", "tag": version_meta["tag"]}]
+            elif hasattr(version, "tag"):
+                if hasattr(pkg, "git"):
+                    meta["repositories"] = [{"url": pkg.git, "type": "git", "tag": str(version.tag)}]
             else:
                 meta["downloads"] = [url]
 

--- a/generate_packages.py
+++ b/generate_packages.py
@@ -146,9 +146,6 @@ def main():
                 meta["repositories"] = [{"url": pkg.git, "type": "git", "commit": version_meta["commit"]}]
             elif "tag" in version_meta and hasattr(pkg, "git"):
                 meta["repositories"] = [{"url": pkg.git, "type": "git", "tag": version_meta["tag"]}]
-            elif hasattr(version, "tag"):
-                if hasattr(pkg, "git"):
-                    meta["repositories"] = [{"url": pkg.git, "type": "git", "tag": str(version.tag)}]
             else:
                 meta["downloads"] = [url]
 


### PR DESCRIPTION
We get some packages to show up as problematic on repology because a version with commit/tag/branch in the version is instead listed with a regularly derived url. E.g. crtm at https://repology.org/repository/spack/problems?start=crtm.
> crtm	crtm	alexanderrichert-noaa@spack	Download link https://github.com/JCSDA/crtm/archive/refs/tags/2.4.0.1.tar.gz is dead (HTTP 404) for more than a month and should be replaced by alive link (see other packages for hints).

This PR causes commit/tag/branch git versions to be listed with repository info. For the crtm version above the diff is:
```diff
                 {
-                    "downloads": [
-                        "https://github.com/JCSDA/crtm/archive/refs/tags/2.4.0.1.tar.gz"
+                    "repositories": [
+                        {
+                            "commit": "7ecad4866c400d7d0db1413348ee225cfa99ff36",
+                            "type": "git",
+                            "url": "https://github.com/JCSDA/crtm.git"
+                        }
                     ],
                     "version": "2.4.0.1"
                 },
```

When both branch/tag and commit are listed, commit is preferred.