### PR TITLE
fix: sort search by package name length

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
           })
 
             this.more_results = results.length > 20;
-            return results.slice(0, 20);
+            return results.sort((a, b) => a.name.length - b.name.length).slice(0, 20);
        },
 
        packagePageUrl(pkg) {


### PR DESCRIPTION
Fixes #30.

![image](https://github.com/user-attachments/assets/80154402-d94f-4655-924a-ff725a40daba)
