### PR TITLE
feat: search by regex

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,9 @@
            return [];
          }
 
+	  const regex = RegExp(this.query)
           const results = this.packages.filter(pkg => {
-            return pkg.name.toLowerCase().includes(this.query.toLowerCase());
+            return regex.test(pkg.name);
           })
 
             this.more_results = results.length > 20;

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
           })
 
             this.more_results = results.length > 20;
-            return results.slice(0, 20);
+            return results.sort((a, b) => a.name.length - b.name.length).slice(0, 20);
        },
 
        packagePageUrl(pkg) {


### PR DESCRIPTION
- [ ]  needs #31 

Might as well. Fast enough. Backwards compatible since all special regex characters (e.g. .) are disallowed in package names. Only change is that we don't convert to lowercase on either query or package name (which is already lowercase).
![image](https://github.com/user-attachments/assets/127c65f4-ffce-418b-ba36-b1a5f6305ce6)
