### PR TITLE
bugfix: javascript needs `replaceAll()`, not `replace()`

### DIFF
--- a/package.html
+++ b/package.html
@@ -68,7 +68,7 @@
       },
 
       packagePyUrl() {
-        var name = this.name.replace("-", "_");
+        var name = this.name.replaceAll("-", "_");
         if (/^[0-9]/.test(name) || _reserved_names.has(name)) {
           name = `_${name}`;
         }


### PR DESCRIPTION
Fixes #39.

#38 replaced the first dash with an underscore, but not the rest.

- [x] Use `replaceAll()` to get the rest.